### PR TITLE
Support Django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 # https://travis-ci.org/django-polymorphic/django-polymorphic
-sudo: True
 language: python
 cache: pip
 dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,6 @@ language: python
 cache: pip
 dist: xenial
 
-python: "3.6"
-
-env:
-  - TOXENV=py27-django111
-  - TOXENV=py34-django111
-  - TOXENV=py34-django20
-  - TOXENV=py35-django111
-  - TOXENV=py35-django20
-  - TOXENV=py35-djangomaster
-  - TOXENV=py36-django111
-  - TOXENV=py36-django20
-  - TOXENV=py36-django21
-  - TOXENV=py36-django22
-  - TOXENV=py36-djangomaster
-  # XXX: Use a matrix to build these?
-  - TOXENV=py36-django111-postgres DB=postgres
-  - TOXENV=py36-django20-postgres DB=postgres
-  - TOXENV=py36-djangomaster-postgres DB=postgres
-
 services:
   - postgres
 addons:
@@ -30,27 +11,36 @@ addons:
 matrix:
   fast_finish: true
   include:
-    - python: "2.7"
-      env: TOXENV=py27-django111
-    - python: "3.5"
-      env: TOXENV=py35-django111
-    - python: "3.5"
-      env: TOXENV=py35-django20
-    - python: "3.5"
-      env: TOXENV=py35-djangomaster
-  exclude:
-    - python: "3.6"
-      env: TOXENV=py27-django111
-    - python: "3.6"
-      env: TOXENV=py35-django111
-    - python: "3.6"
-      env: TOXENV=py35-django20
-    - python: "3.6"
-      env: TOXENV=py35-djangomaster
+    # Django 1.11: Python 2.7, 3.4, 3.5, or 3.6
+    - { env: TOXENV=py27-django111, python: 2.7 }
+    - { env: TOXENV=py34-django111, python: 3.4 }
+    - { env: TOXENV=py35-django111, python: 3.5 }
+    - { env: TOXENV=py36-django111, python: 3.6 }
+    - { env: TOXENV=py36-django111-postgres DB=postgres, python: 3.6 }
+    # Django 2.0: Python 3.4, 3.5, or 3.6
+    - { env: TOXENV=py34-django20, python: 3.4 }
+    - { env: TOXENV=py35-django20, python: 3.5 }
+    - { env: TOXENV=py36-django20, python: 3.6 }
+    - { env: TOXENV=py36-django20-postgres DB=postgres, python: 3.6 }
+    # Django 2.1: Python 3.6, or 3.7
+    - { env: TOXENV=py36-django21, python: 3.6 }
+    - { env: TOXENV=py37-django21, python: 3.7 }
+    - { env: TOXENV=py37-django21-postgres DB=postgres, python: 3.7 }
+    # Django 2.2: Python 3.6, or 3.7
+    - { env: TOXENV=py36-django22, python: 3.6 }
+    - { env: TOXENV=py37-django22, python: 3.7 }
+    - { env: TOXENV=py37-django22-postgres DB=postgres, python: 3.7 }
+    # Django development master (direct from GitHub source):
+    - { env: TOXENV=py35-djangomaster, python: 3.5 }
+    - { env: TOXENV=py36-djangomaster, python: 3.6 }
+    - { env: TOXENV=py37-djangomaster, python: 3.7 }
+    - { env: TOXENV=py37-djangomaster-postgres DB=postgres, python: 3.7 }
+
   allow_failures:
-    - env: TOXENV=py35-djangomaster
-    - env: TOXENV=py36-djangomaster
-    - env: TOXENV=py36-djangomaster-postgres DB=postgres
+    - { env: TOXENV=py35-djangomaster, python: 3.5 }
+    - { env: TOXENV=py36-djangomaster, python: 3.6 }
+    - { env: TOXENV=py37-djangomaster, python: 3.7 }
+    - { env: TOXENV=py37-djangomaster-postgres DB=postgres, python: 3.7 }
 
 cache:
   directories:

--- a/polymorphic/formsets/utils.py
+++ b/polymorphic/formsets/utils.py
@@ -10,7 +10,10 @@ def add_media(dest, media):
 
     Only required for Django < 2.0
     """
-    if django.VERSION >= (2, 0):
+    if django.VERSION >= (2, 2):
+        dest._css_lists.extend(media._css_lists)
+        dest._js_lists.extend(media._js_lists)
+    elif django.VERSION >= (2, 0):
         combined = dest + media
         dest._css = combined._css
         dest._js = combined._js

--- a/polymorphic/tests/test_orm.py
+++ b/polymorphic/tests/test_orm.py
@@ -226,7 +226,7 @@ class PolymorphicTests(TransactionTestCase):
     def test_defer_fields(self):
         self.create_model2abcd()
 
-        objects_deferred = Model2A.objects.defer('field1')
+        objects_deferred = Model2A.objects.defer('field1').order_by('id')
 
         self.assertNotIn('field1', objects_deferred[0].__dict__, 'field1 was not deferred (using defer())')
         self.assertRegex(repr(objects_deferred[0]),

--- a/runtests.py
+++ b/runtests.py
@@ -46,6 +46,7 @@ if not settings.configured:
         MIDDLEWARE=(
             'django.contrib.auth.middleware.AuthenticationMiddleware',
             'django.contrib.messages.middleware.MessageMiddleware',
+            'django.contrib.sessions.middleware.SessionMiddleware',
         ),
         SITE_ID=3,
         TEMPLATES=[{

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 	Programming Language :: Python :: 3.4
 	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
-	Programming Language :: Python :: 3.7
+        Programming Language :: Python :: 3.7
 	Topic :: Database
 
 [options]


### PR DESCRIPTION
@auvipy Added a few changes to get Django 2.2 fully working.

- add fix to formsets.utils.add_media to support Django 2.2
- add Django 2.2 to and refactor test matrix
- add missing middleware to get tests working on Django 2+
- fix a flaky test, queryset results wouldn't always come back in the same order

The master branch tests are failing because Django has started removing support for python2, so django.utils.six is no longer available.